### PR TITLE
fix: remove pathfinder requirement for bfa zones

### DIFF
--- a/Mounts.lua
+++ b/Mounts.lua
@@ -826,8 +826,6 @@ do
 	}
 	function mounts:isFlyLocation(instanceID)
 		if self.continentsGround[instanceID]
-		-- Битва за Азерот
-		or bfaLocations[instanceID] and not IsSpellKnown(278833)
 		then return false end
 
 		return true


### PR DESCRIPTION
Since 10.1 Pathfinder is not a requerement for flying in bfa zone. So i remove it, since I currently leveling on bfa at level 30 ^^